### PR TITLE
Update Docker workflow and base images, upgrade action versions

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,15 +1,10 @@
 name: Build and Publish
 
-#on:
-  # run it on push to the default repository branch
-#  push:
-#    branches: [main]
-  # run it during pull request
-#  pull_request:
-
-
-on: [workflow_dispatch]
-
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
 
 jobs:
   # define job to build and publish docker image
@@ -22,24 +17,24 @@ jobs:
     steps:
       # Get the repository's code
       - name: Checkout
-        uses: actions/checkout@v3.0.1
+        uses: actions/checkout@v6
       # https://github.com/docker/setup-qemu-action
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1.2.0
+        uses: docker/setup-qemu-action@v3
       # https://github.com/docker/setup-buildx-action
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v1.6.0
+        uses: docker/setup-buildx-action@v3
 
       - name: Login to DockerHub
-        uses: docker/login-action@v1.14.1
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-          
+
       - name: Docker meta
         id: librespot # you'll use this in the next step
-        uses: docker/metadata-action@v3.7.0
+        uses: docker/metadata-action@v5
         with:
           # list of Docker images to use as base name for tags
           images: |
@@ -50,13 +45,9 @@ jobs:
             type=ref,event=branch
             type=ref,event=pr
             type=semver,pattern={{version}}
-          #  type=raw,value=latest
-          #  type=semver,pattern={{major}}.{{minor}}
-          #  type=semver,pattern={{major}}
-          #  type=sha
-      
+
       - name: Build and push
-        uses: docker/build-push-action@v2.10.0
+        uses: docker/build-push-action@v6
         with:
           context: .
           platforms: linux/arm/v7

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,20 @@
-FROM alpine:3.16 AS build 
+FROM alpine:3.21 AS build
 RUN apk -U --no-cache add \
 	git \
 	build-base \
-    avahi-dev \
+	avahi-dev \
 	autoconf \
 	automake \
 	libtool \
 	libdaemon-dev \
-	libressl-dev \
+	openssl-dev \
 	libconfig-dev \
 	libstdc++ \
 	gcc \
 	rust \
-	cargo 
+	cargo
 
-RUN cd /root \ 
+RUN cd /root \
 	&& mkdir -p ~/.cargo \
 	&& echo $'[net]\n\
 	git-fetch-with-cli = true\n'\
@@ -22,18 +22,15 @@ RUN cd /root \
 	&& mkdir -p /root/git \
 	&& cd /root/git \
 	&& git clone https://github.com/librespot-org/librespot.git . \
-	&& git checkout tags/v0.4.2 \
+	&& git checkout tags/v0.8.0 \
 	&& cargo build --release --no-default-features --features "with-dns-sd"
 
-#RUN ls -al /root/git/target/release/ \
-#	&& halt 10
-
-FROM alpine:3.16
+FROM alpine:3.21
 RUN apk -U --no-cache add \
-    libtool \
-    libconfig-dev \
+	libtool \
+	libconfig-dev \
 	avahi-dev \
-	dbus 
+	dbus
 
 COPY --from=build /root/git/target/release/librespot /usr/bin/librespot
 COPY bootstrap.sh /start


### PR DESCRIPTION
## Summary
This PR modernizes the CI/CD pipeline and Docker configuration by updating GitHub Actions to their latest versions, upgrading base images, and re-enabling automated builds on push and pull requests.

## Key Changes

### GitHub Actions Workflow (`docker-image.yml`)
- **Re-enabled automated triggers**: Restored `push` (on main branch) and `pull_request` triggers alongside `workflow_dispatch`
- **Updated action versions**:
  - `actions/checkout`: v3.0.1 → v6
  - `docker/setup-qemu-action`: v1.2.0 → v3
  - `docker/setup-buildx-action`: v1.6.0 → v3
  - `docker/login-action`: v1.14.1 → v3
  - `docker/metadata-action`: v3.7.0 → v5
  - `docker/build-push-action`: v2.10.0 → v6
- **Code cleanup**: Removed commented-out configuration options and fixed trailing whitespace

### Dockerfile
- **Base image upgrade**: Alpine 3.16 → 3.21 (both build and runtime stages)
- **Dependency update**: `libressl-dev` → `openssl-dev` (Alpine 3.21 uses OpenSSL instead of LibreSSL)
- **Librespot version bump**: v0.4.2 → v0.8.0
- **Code cleanup**: Fixed indentation inconsistencies and removed commented-out debug code

## Notable Details
- The workflow now automatically builds on every push to main and pull request, improving CI/CD coverage
- Alpine 3.21 is a more recent stable release with security updates and improved compatibility
- Librespot v0.8.0 includes significant improvements and bug fixes over v0.4.2

https://claude.ai/code/session_01DMmbtZDANgHV8x98PPrNJr